### PR TITLE
Automatic update of dependency virtualenv from 15.2.0 to 16.0.0

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "990e850c17fb6d3af6f96526c67fb584ab1aab9484f2eb1cd7245da8238077b5"
+            "sha256": "f3458d13c1bafd59a6f42b25507773507186c890f88db04abc3fcd52477527c9"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -167,10 +167,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:1d7e241b431e7afce47e77f8843a276f652699d1fa4f93b9d8ce0076fd7b0b54",
-                "sha256:e8e05d4714a1c51a2f5921e62f547fcb0f713ebbe959e0a7f585cc8bef71d11f"
+                "sha256:2ce32cd126117ce2c539f0134eb89de91a8413a29baac49cbab3eb50e2026669",
+                "sha256:ca07b4c0b54e14a91af9f34d0919790b016923d157afda5efdde55c96718f752"
             ],
-            "version": "==15.2.0"
+            "index": "pypi",
+            "version": "==16.0.0"
         }
     },
     "develop": {


### PR DESCRIPTION
Dependency virtualenv was used in version 15.2.0, but the current latest version is 16.0.0.