### PR TITLE
Add build trigger with generic webhook

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -9,6 +9,28 @@
     release:
       jobs:
         - upload-pypi-sesheta
+    post:
+      jobs:
+        - "trigger-build":
+            vars:
+              cluster: "paas.psi.redhat.com"
+              namespace: "thoth-test-core"
+              buildConfigName: "solver-fedora-29-py37"
+        - "trigger-build":
+            vars:
+              cluster: "paas.psi.redhat.com"
+              namespace: "thoth-test-core"
+              buildConfigName: "solver-fedora-29-py36"
+        - "trigger-build":
+            vars:
+              cluster: "paas.psi.redhat.com"
+              namespace: "thoth-test-core"
+              buildConfigName: "solver-fedora-28-py36"
+        - "trigger-build":
+            vars:
+              cluster: "paas.psi.redhat.com"
+              namespace: "thoth-test-core"
+              buildConfigName: "solver-ubi-8-py36"
     kebechet-auto-gate:
       queue: thoth-station/core
       jobs:

--- a/openshift/buildConfig-template.yaml
+++ b/openshift/buildConfig-template.yaml
@@ -101,6 +101,10 @@ objects:
       triggers:
         - type: ImageChange
           imageChange: {}
+        - type: "Generic"
+          generic:
+            secretReference:
+              name: generic-webhook-secret
 
   - kind: BuildConfig
     apiVersion: v1
@@ -166,6 +170,10 @@ objects:
       triggers:
         - type: ImageChange
           imageChange: {}
+        - type: "Generic"
+          generic:
+            secretReference:
+              name: generic-webhook-secret
 
   - kind: BuildConfig
     apiVersion: v1
@@ -229,6 +237,10 @@ objects:
       triggers:
         - type: ImageChange
           imageChange: {}
+        - type: "Generic"
+          generic:
+            secretReference:
+              name: generic-webhook-secret
 
   - kind: BuildConfig
     apiVersion: v1
@@ -293,3 +305,7 @@ objects:
       triggers:
         - type: "ImageChange"
           imageChange: {}
+        - type: "Generic"
+          generic:
+            secretReference:
+              name: generic-webhook-secret


### PR DESCRIPTION
Add generic trigger webhook to buildconfig
The `generic-webhook-secret` secret is a prerequisite for using this new build config.
Add trigger build job to zuul post pipeline job list