### PR TITLE
Reverse order of imports during venv instrumentation

### DIFF
--- a/tests/python/test_instrument.py
+++ b/tests/python/test_instrument.py
@@ -111,6 +111,14 @@ class TestInstrument(SolverTestCase):
         discovered_metadata.pop("files")
         assert discovered_metadata == metadata
 
+    def test_package_clash(self, venv):
+        """Test packages which are dependencies of this solver do not affect results of data gathering."""
+        import click
+        assert click.__version__ != "3.0"
+        venv.install("click==3.0")
+        discovered_metadata = get_package_metadata(venv.python, "click")
+        assert discovered_metadata.get("version") == "3.0"
+
     def test_execute_env_function_raise_on_error(self, venv):
         """Assert raising an error (error propagation turned on by default)."""
         with pytest.raises(ValueError) as exc:

--- a/thoth/solver/python/instrument.py
+++ b/thoth/solver/python/instrument.py
@@ -121,6 +121,9 @@ def execute_env_function(python_bin, function, *, env=None, raise_on_error=True,
     _LOGGER.debug("Executing the following command in Python interpreter (env: %r): %r", env, cmd)
     res = run_command(cmd, env=env, is_json=is_json, raise_on_error=False)
 
+    _LOGGER.debug("stdout during command execution: %s", res.stdout)
+    _LOGGER.debug("stderr during command execution: %s", res.stderr)
+
     if raise_on_error and res.return_code != 0:
         raise ValueError("Failed to successfully execute function in Python interpreter: {}".format(res.stderr))
 

--- a/thoth/solver/python/instrument.py
+++ b/thoth/solver/python/instrument.py
@@ -55,9 +55,11 @@ def _find_distribution_name(package_name):
 
 def _get_importlib_metadata_metadata(package_name):
     """"Retrieve all the metadata for the given package."""
+    import sys
+    sys.path = sys.path[::-1]
+
     import importlib_metadata
     import json
-    import sys
 
     print(json.dumps(dict(importlib_metadata.metadata(package_name).items())))
     sys.exit(0)
@@ -66,6 +68,8 @@ def _get_importlib_metadata_metadata(package_name):
 def _get_importlib_metadata_version(package_name):
     """"Retrieve version based for the given package."""
     import sys
+    sys.path = sys.path[::-1]
+
     import importlib_metadata
 
     print(importlib_metadata.version(package_name), end="")
@@ -75,6 +79,8 @@ def _get_importlib_metadata_version(package_name):
 def _get_importlib_metadata_requires(package_name):
     """"Retrieve requires based for the given package."""
     import sys
+    sys.path = sys.path[::-1]
+
     import importlib_metadata
     import json
 
@@ -84,9 +90,11 @@ def _get_importlib_metadata_requires(package_name):
 
 def _get_importlib_metadata_entry_points(package_name):
     """Retrieve information about entry-points for the given package."""
+    import sys
+    sys.path = sys.path[::-1]
+
     import importlib_metadata
     import json
-    import sys
 
     entry_points = importlib_metadata.distribution(package_name).entry_points
     print(json.dumps([{"name": ep.name, "value": ep.value, "group": ep.group} for ep in entry_points]))
@@ -95,9 +103,11 @@ def _get_importlib_metadata_entry_points(package_name):
 
 def _get_importlib_metadata_files(package_name):
     """Retrieve information about files present for the given package."""
+    import sys
+    sys.path = sys.path[::-1]
+
     from importlib_metadata import files
     import json
-    import sys
 
     print(
         json.dumps(
@@ -140,7 +150,8 @@ def get_package_metadata(python_bin, package_name):
     # a dependency of this package, but it is not installed in the created virtual environment.
     # Inject the current path to the created environment. Note however,
     # we need to make sure importlib_metadata correctly handles metadata of packages which are dependencies of this
-    # package - it works as expected.
+    # package - each function executed in the virtual environment should reverse sys.path to give precedence
+    # in importing packages from virtual environment, and then, import from the environment where solver runs in.
     return {
         "metadata": execute_env_function(
             python_bin,

--- a/thoth/solver/python/python.py
+++ b/thoth/solver/python/python.py
@@ -343,6 +343,14 @@ def _do_resolve_index(
             continue
 
         packages.append(extracted_metadata)
+        if package_version != extracted_metadata["package_version"]:
+            _LOGGER.warning(
+                "Requested to install package %r in version %r but installed version is %r",
+                package_name,
+                package_version,
+                extracted_metadata["package_version"]
+            )
+
         extracted_metadata["package_version_requested"] = package_version
         _fill_hashes(source, package_name, package_version, extracted_metadata)
 

--- a/thoth/solver/python/python.py
+++ b/thoth/solver/python/python.py
@@ -79,7 +79,8 @@ def _install_requirement(
             cmd += " --trusted-host {}".format(trusted_host)
 
         _LOGGER.debug("Installing requirement %r in version %r", package, version)
-        run_command(cmd)
+        result = run_command(cmd)
+        _LOGGER.debug("Log during installation:\nstdout: %s\nstderr:%s", result.stdout, result.stderr)
         yield
     finally:
         if clean:


### PR DESCRIPTION
This way, we will import packages which are present in the virtual env
first, then injecteted packages into virtual environment.

This is a fix for an issue where we analyze click package, which is also a 
dependency of thoth-solver. As the precedence is given first to path
injected by PYTHONPATH environment variable, we always return metadata for
click which is installed for thoth-solver (not the analyzed one).

Depends-On: #327 #326 