### PR TITLE
Remove ttl configuration for cleanup

### DIFF
--- a/openshift/job-template.yaml
+++ b/openshift/job-template.yaml
@@ -79,7 +79,6 @@ objects:
         operator: graph-sync
         task: solver
         mark: cleanup
-        ttl: "2h"
     spec:
       template:
         metadata:


### PR DESCRIPTION
Let's have one centralized point for conifguring this - cleanup job itself.

Related: https://github.com/thoth-station/cleanup-job/pull/215