### PR TITLE
Lower requests for running solver jobs

### DIFF
--- a/openshift/job-template.yaml
+++ b/openshift/job-template.yaml
@@ -122,7 +122,7 @@ objects:
               resources:
                 limits:
                   cpu: 1
-                  memory: 3Gi
+                  memory: 1Gi
                 requests:
                   cpu: 1
-                  memory: 3Gi
+                  memory: 1Gi


### PR DESCRIPTION
* as solver resolves one package-version at a time, we should be fine with
  lowering memory requests needed for a solver job