### PR TITLE
Use arbitrary equality for solvers

### DIFF
--- a/thoth/solver/python/python.py
+++ b/thoth/solver/python/python.py
@@ -71,7 +71,7 @@ def _install_requirement(python_bin, package, version=None, index_url=None, clea
     try:
         cmd = "{} -m pip install --force-reinstall --no-cache-dir --no-deps {}".format(python_bin, quote(package))
         if version:
-            cmd += "=={}".format(quote(version))
+            cmd += "==={}".format(quote(version))
         if index_url:
             cmd += ' --index-url "{}" '.format(quote(index_url))
             # Supply trusted host by default so we do not get errors - it safe to


### PR DESCRIPTION
This addresses issues for unsolved packages - for example ansible==2.0.0 will
install ansible==2.0.0.0 leaving ansible=2.0.0 marked as unsolved in the
knowledge graph.