### PR TITLE
Fix when no output was produced and JSON flag was set to true

### DIFF
--- a/thoth/solver/python/instrument.py
+++ b/thoth/solver/python/instrument.py
@@ -169,11 +169,12 @@ def execute_env_function(
     _LOGGER.debug("Executing the following command in Python interpreter (env: %r): %r", env, cmd)
     res = run_command(cmd, env=env, is_json=is_json, raise_on_error=False)
 
-    _LOGGER.debug("stdout during command execution: %s", res.stdout)
     _LOGGER.debug("stderr during command execution: %s", res.stderr)
 
     if raise_on_error and res.return_code != 0:
         raise ValueError("Failed to successfully execute function in Python interpreter: {}".format(res.stderr))
+
+    _LOGGER.debug("stdout during command execution: %s", res.stdout)
 
     if res.return_code == 0:
         stdout = res.stdout  # type: Union[str, Dict[str, Any]]


### PR DESCRIPTION
If the JSON flag is set to True and no output is produced, solver raises an
exception when trying to serialize JSON output. This patch moves the
serialization after the check so that the undesired exception does not occur.