### PR TITLE
Use s2i as a base image for solver-f32-py38

### DIFF
--- a/dockerfile/Dockerfile.solver-fedora-32-py38
+++ b/dockerfile/Dockerfile.solver-fedora-32-py38
@@ -1,4 +1,4 @@
-FROM fedora:32
+FROM quay.io/thoth-station/s2i-thoth-f32-py38:v0.23.2
 
 ENV \
   LANG=en_US.UTF-8 \


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/solver/issues/417

## This introduces a breaking change

- [x] No
