### PR TITLE
WIP: Use s2i as a base image for solver-fedora-31-py37

### DIFF
--- a/dockerfile/Dockerfile.solver-fedora-31-py37
+++ b/dockerfile/Dockerfile.solver-fedora-31-py37
@@ -1,4 +1,4 @@
-FROM fedora:31
+FROM quay.io/thoth-station/s2i-thoth-f31-py37:v0.23.2
 
 ENV \
 LANG=en_US.UTF-8 \


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/solver/issues/417

## This introduces a breaking change

- [x] No
