### PR TITLE
Explicitly turn on pre-releases in Python dependency parser

### DIFF
--- a/tests/python/python_solver_test.py
+++ b/tests/python/python_solver_test.py
@@ -52,7 +52,19 @@ class TestPythonSolver(SolverTestCase):
         "package_specification,resolved_versions",
         [
             (
-                "selinon>=0.1.0rc0,<1.1.0",
+                "selinon>=1.0.0rc1,<1.1.0",
+                {
+                    "selinon": {
+                        ("1.0.0rc1", "https://pypi.org/simple"),
+                        ("1.0.0rc2", "https://pypi.org/simple"),
+                        ("1.0.0rc3", "https://pypi.org/simple"),
+                        ("1.0.0rc4", "https://pypi.org/simple"),
+                        ("1.0.0", "https://pypi.org/simple"),
+                    },
+                },
+            ),
+            (
+                "selinon<=1.1.0",
                 {
                     "selinon": {
                         ("0.1.0rc2", "https://pypi.org/simple"),
@@ -68,12 +80,9 @@ class TestPythonSolver(SolverTestCase):
                         ("1.0.0rc3", "https://pypi.org/simple"),
                         ("1.0.0rc4", "https://pypi.org/simple"),
                         ("1.0.0", "https://pypi.org/simple"),
+                        ("1.1.0", "https://pypi.org/simple"),
                     },
                 },
-            ),
-            (
-                "selinon<=1.1.0",
-                {"selinon": {("1.0.0", "https://pypi.org/simple"), ("1.1.0", "https://pypi.org/simple")}},
             ),
             ("tensorflow==2.0.0", {"tensorflow": {("2.0.0", "https://pypi.org/simple")}}),
         ],

--- a/thoth/solver/python/python_solver.py
+++ b/thoth/solver/python/python_solver.py
@@ -67,7 +67,10 @@ class PythonDependencyParser(DependencyParser):
         :param spec: str, for example "Django>=1.5,<1.8"
         :return: requirement for the Python package
         """
-        return Requirement(spec)
+        req = Requirement(spec)
+        # We explictly allow pre-releases here as we want to handle them in resolver's pipeline units.
+        req.specifier.prereleases = True
+        return req
 
     def parse(self, specs):  # type: (List[str]) -> List[Requirement]
         """Parse specs."""


### PR DESCRIPTION
## Related Issues and Dependencies

When parsing pre-releases with no specifier, resolver removes packages that have pre-releases. This is undesired behavior as we want to handle pre-releases in pipeline units.

## This introduces a breaking change

- [x] No
