### PR TITLE
Execute solvers with app script to call solver python cli

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,1 +1,0 @@
-thoth/solver/cli.py

--- a/app.sh
+++ b/app.sh
@@ -1,0 +1,1 @@
+python3 thoth/solver/cli.py python


### PR DESCRIPTION
## This Pull Request implements

Execute solvers with app script to call solver python cli
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Description
As we moved to s2i based solver, the cli command is not being passed with **command-options**, which earlier use to happen with entrypoint and cmd feature of the dockerfile based image. 
with this we can execute the **app.sh** script to have the same behaviour.

```
{"name": "thoth.common", "levelname": "WARNING", "module": "logging", "lineno": 344, "funcname": "init_logging", "created": 1614841351.7242138, "asctime": "2021-03-04 07:02:31,724", "msecs": 724.2138385772705, "relative_created": 760.1261138916016, "process": 8, "message": "Logging to a Sentry instance is turned off"}
Usage: app.py [OPTIONS] COMMAND [ARGS]...

  Thoth solver command line interface.

Options:
  -v, --verbose  Be verbose about what's going on.
  --version      Print solver version and exit.
  --help         Show this message and exit.

Commands:
  python  Manipulate with dependency requirements using PyPI.

```