### PR TITLE
Use thoth.solver logger in the CLI setup

### DIFF
--- a/thoth/solver/cli.py
+++ b/thoth/solver/cli.py
@@ -33,7 +33,7 @@ from thoth.solver.python import resolve as resolve_python
 
 init_logging()
 
-_LOG = logging.getLogger(__name__)
+_LOG = logging.getLogger("thoth.solver")
 
 
 def _print_version(ctx, _, value):


### PR DESCRIPTION
## This introduces a breaking change

- [x] No

## Description

When running thoth-solver locally, the logger is not properly setup to debug level as the logger is called "thoth.solver.cli" instead of "thoth.solver".
