### PR TITLE
Look for dependency versions on separate dependency indexes

### DIFF
--- a/thoth/solver/cli.py
+++ b/thoth/solver/cli.py
@@ -70,7 +70,12 @@ def cli(ctx=None, verbose=0):
 @cli.command()
 @click.pass_context
 @click.option(
-    "--requirements", "-r", type=str, envvar="THOTH_SOLVER_PACKAGES", required=True, help="Requirements to be solved.",
+    "--requirements",
+    "-r",
+    type=str,
+    envvar="THOTH_SOLVER_PACKAGES",
+    required=True,
+    help="Requirements to be solved.",
 )
 @click.option(
     "--index",
@@ -80,6 +85,16 @@ def cli(ctx=None, verbose=0):
     show_default=True,
     default="https://pypi.org/simple",
     help="A comma separated list of Python indexes to be used when resolving version ranges.",
+)
+@click.option(
+    "--dependency-index",
+    "-d",
+    type=str,
+    envvar="THOTH_SOLVER_DEPENDENCY_INDEXES",
+    show_default=True,
+    default=None,
+    help="A comma separated list of Python indexes to be used when checking dependency versions, "
+    "defaults to --index if not provided explicitly.",
 )
 @click.option(
     "--output",
@@ -123,6 +138,7 @@ def python(
     click_ctx,
     requirements,
     index=None,
+    dependency_index=None,
     python_version=3,
     exclude_packages=None,
     output=None,
@@ -139,9 +155,13 @@ def python(
         _LOG.error("No requirements specified, exiting")
         sys.exit(1)
 
+    index_urls = index.split(",") if index else ("https://pypi.org/simple",)
+    dependency_index_urls = dependency_index.split(",") if dependency_index else index_urls
+
     result = resolve_python(
         requirements,
-        index_urls=index.split(",") if index else ("https://pypi.org/simple",),
+        index_urls=index_urls,
+        dependency_index_urls=dependency_index_urls,
         python_version=int(python_version),
         transitive=not no_transitive,
         exclude_packages=set(map(str.strip, (exclude_packages or "").split(","))),

--- a/thoth/solver/python/python.py
+++ b/thoth/solver/python/python.py
@@ -184,8 +184,8 @@ def extract_metadata(metadata, index_url):
     return result
 
 
-def _resolve_versions(solver, source, package_name, version_spec):
-    # type: (PythonSolver, Source, str, str) -> List[str]
+def _resolve_versions(solver, package_name, version_spec):
+    # type: (PythonSolver, str, str) -> List[str]
     try:
         resolved_versions = solver.solve([package_name + (version_spec or "")])
     except NotFoundError:
@@ -193,7 +193,7 @@ def _resolve_versions(solver, source, package_name, version_spec):
             "No versions were resolved for %r with version specification %r for package index %r",
             package_name,
             version_spec,
-            source.url,
+            solver.releases_fetcher.source.url
         )
         return []
     except Exception:  # pylint: disable=broad-except
@@ -252,7 +252,7 @@ def _do_resolve_index(python_bin, solver, all_solvers, requirements, exclude_pac
         _LOGGER.info(
             "Resolving package %r with version specifier %r from %r", dependency.name, version_spec, source.url,
         )
-        resolved_versions = _resolve_versions(solver, source, dependency.name, version_spec)
+        resolved_versions = _resolve_versions(solver, dependency.name, version_spec)
         if not resolved_versions:
             _LOGGER.warning("No versions were resolved for dependency %r in version %r", dependency.name, version_spec)
             error_report = {
@@ -343,7 +343,7 @@ def _do_resolve_index(python_bin, solver, all_solvers, requirements, exclude_pac
                     dep_solver.releases_fetcher.index_url,
                 )
                 resolved_versions = _resolve_versions(
-                    dep_solver, dep_solver.releases_fetcher.source, dependency_name, dependency_specifier or "",
+                    dep_solver, dependency_name, dependency_specifier or "",
                 )
                 _LOGGER.debug(
                     "Resolved versions for package %r with range specifier %r: %s",


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/solver/issues/5111
Related: https://github.com/thoth-station/graph-refresh-job/issues/669
Related: https://github.com/thoth-station/thoth-application/issues/2272

## This introduces a breaking change

- [x] No

## Description

Pass all registered indexes when scheduling solver workflow.
